### PR TITLE
(fix) Handle no labels

### DIFF
--- a/sentry_taiga/plugin.py
+++ b/sentry_taiga/plugin.py
@@ -101,7 +101,8 @@ class TaigaPlugin(IssuePlugin):
             'subject': form_data['title'],
             'status': default_us_status,
             'description': form_data['description'],
-            'tags': map(lambda x:x.strip(), labels.split(","))}
+            'tags': map(lambda x:x.strip(), labels.split(",")) if labels else None
+            }
 
         us = project.add_user_story(**data)
 


### PR DESCRIPTION
Currently it crashes if you try to create a User Story and haven't entered any labels (optional field). This handles the case where it's empty and doesn't crash. 