### PR TITLE
Change placeholder text to be less confusing

### DIFF
--- a/sentry_taiga/plugin.py
+++ b/sentry_taiga/plugin.py
@@ -36,7 +36,7 @@ class TaigaOptionsForm(forms.Form):
 
     taiga_project = forms.CharField(
         label=_('Taiga Project Slug'),
-        widget=forms.TextInput(attrs={'placeholder': 'e.g. https://tree.taiga.io/project/<project-slug>'}),
+        widget=forms.TextInput(attrs={'placeholder': 'e.g. project-slug'}),
         help_text=_('Enter your project slug.'),
         required=True)
 


### PR DESCRIPTION
What you actually have to enter is not the full URL, and I found the placeholder text to be misleading. Reverting to what it used to be seems clearer. 