### PR TITLE
fix(integrations) Generate correct link to Taiga User Story

### DIFF
--- a/sentry_taiga/plugin.py
+++ b/sentry_taiga/plugin.py
@@ -18,9 +18,18 @@ class TaigaOptionsForm(forms.Form):
     taiga_url = forms.CharField(
         label=_('Taiga URL'),
         widget=forms.TextInput(attrs={'placeholder': 
-                                      'e.g. https://api.taiga.io'}),
+                                      'e.g. https://tree.taiga.io'}),
         help_text=_('Enter the URL for your Taiga server'),
-        required=True)
+        required=True,
+        initial='https://tree.taiga.io')
+
+    taiga_api = forms.CharField(
+        label=_('Taiga API'),
+        widget=forms.TextInput(attrs={'placeholder': 
+                                      'e.g. https://api.taiga.io'}),
+        help_text=_('Enter the Taiga API URL'),
+        required=True,
+        initial='https://api.taiga.io')
 
     taiga_username = forms.CharField(
         label=_('Taiga User Name'),
@@ -73,12 +82,13 @@ class TaigaPlugin(IssuePlugin):
     def create_issue(self, request, group, form_data, **kwargs):
 
         url = self.get_option('taiga_url', group.project)
+        api = self.get_option('taiga_api', group.project)
         username = self.get_option('taiga_username', group.project)
         password = self.get_option('taiga_password', group.project)
         project_slug = self.get_option('taiga_project', group.project)
         labels = self.get_option('taiga_labels', group.project)
         
-        tg = TaigaAPI(host=url)
+        tg = TaigaAPI(host=api)
 
         try:
             tg.auth(username=username, password=password)


### PR DESCRIPTION
This adds an additional pre-populated field to the Taiga integration configuration for the Taiga URL and Taiga API URL. Most users will use the pre-populated fields, but it can be run on-premise so it needs to handle that. 

Gif of new behavior: https://cl.ly/3o1g2D3u1z0l
Gif of current behavior: https://cl.ly/372W3q2Q3a09
